### PR TITLE
unit tests added

### DIFF
--- a/examples/DetectWindowsVersionExample/DetectWindowsVersionExample.sln
+++ b/examples/DetectWindowsVersionExample/DetectWindowsVersionExample.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSVersionExtension", "..\..
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DetectWindowsVersion", "DetectWindowsVersion\DetectWindowsVersion.csproj", "{670CE219-9503-41E0-8E51-22058A9C61A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSVersionExtensionTests", "..\..\sources\OSVersionExtensionTests\OSVersionExtensionTests\OSVersionExtensionTests.csproj", "{5E9D9588-51D2-4658-8CE5-C061F36E9499}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{670CE219-9503-41E0-8E51-22058A9C61A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{670CE219-9503-41E0-8E51-22058A9C61A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{670CE219-9503-41E0-8E51-22058A9C61A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E9D9588-51D2-4658-8CE5-C061F36E9499}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E9D9588-51D2-4658-8CE5-C061F36E9499}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E9D9588-51D2-4658-8CE5-C061F36E9499}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E9D9588-51D2-4658-8CE5-C061F36E9499}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sources/OSVersionExt/Win32API/Win32ApiEnums.cs
+++ b/sources/OSVersionExt/Win32API/Win32ApiEnums.cs
@@ -101,18 +101,18 @@ namespace OSVersionExt.Win32API
     public struct OSVERSIONINFOEX
     {
         // The OSVersionInfoSize field must be set to Marshal.SizeOf(typeof(OSVERSIONINFOEX))
-        internal int OSVersionInfoSize;
-        internal int MajorVersion;
-        internal int MinorVersion;
-        internal int BuildNumber;
-        internal int PlatformId;
+        public int OSVersionInfoSize;
+        public int MajorVersion;
+        public int MinorVersion;
+        public int BuildNumber;
+        public int PlatformId;
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
-        internal string CSDVersion;
-        internal ushort ServicePackMajor;
-        internal ushort ServicePackMinor;
-        internal SuiteMask SuiteMask;
-        internal ProductType ProductType;
-        internal byte Reserved;
+        public string CSDVersion;
+        public ushort ServicePackMajor;
+        public ushort ServicePackMinor;
+        public SuiteMask SuiteMask;
+        public ProductType ProductType;
+        public byte Reserved;
     }
 
 }

--- a/sources/OSVersionExtensionTests/OSVersionExtensionTests/OSDetectionRules.cs
+++ b/sources/OSVersionExtensionTests/OSVersionExtensionTests/OSDetectionRules.cs
@@ -1,0 +1,172 @@
+﻿using OSVersionExt;
+using OSVersionExt.Win32API;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OSVersionExtensionTests
+{
+    internal static class Windows10Rules
+    {
+        internal const int MAJORVERSION = 10;
+        internal const int MINORVERSION = 0;
+        internal const ProductType PRODUCTTYPE = ProductType.Workstation;
+    }
+
+    internal static class WindowsServer20162019ServerRules
+    {
+        internal const int MAJORVERSION = 10;
+        internal const int MINORVERSION = 0;
+        internal const ProductType PRODUCTTYPE = ProductType.Server;
+    }
+
+    internal static class WindowsServer20162019DomainControllerRules
+    {
+        internal const int MAJORVERSION = 10;
+        internal const int MINORVERSION = 0;
+        internal const ProductType PRODUCTTYPE = ProductType.DomainController;
+    }
+
+    internal static class WindowsServer2012R2ServerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 3;
+        internal const ProductType PRODUCTTYPE = ProductType.Server;
+    }
+
+    internal static class WindowsServer2012R29DomainControllerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 3;
+        internal const ProductType PRODUCTTYPE = ProductType.DomainController;
+    }
+
+    internal static class Windows81Rules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 3;
+        internal const ProductType PRODUCTTYPE = ProductType.Workstation;
+    }
+
+    internal static class Windows8Rules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 2;
+        internal const ProductType PRODUCTTYPE = ProductType.Workstation;
+    }
+
+    internal static class WindowsServer2012ServerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 2;
+        internal const ProductType PRODUCTTYPE = ProductType.Server;
+    }
+
+    internal static class WindowsServer2012DomainControllerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 2;
+        internal const ProductType PRODUCTTYPE = ProductType.DomainController;
+    }
+
+    internal static class Windows7Rules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 1;
+        internal const ProductType PRODUCTTYPE = ProductType.Workstation;
+    }
+
+    internal static class WindowsServer2008R2ServerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 1;
+        internal const ProductType PRODUCTTYPE = ProductType.Server;
+    }
+
+    internal static class WindowsServer2008R2DomainControllerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 1;
+        internal const ProductType PRODUCTTYPE = ProductType.DomainController;
+    }
+
+    internal static class WindowsServer2008ServerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 0;
+        internal const ProductType PRODUCTTYPE = ProductType.Server;
+    }
+
+    internal static class WindowsServer2008DomainControllerRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 0;
+        internal const ProductType PRODUCTTYPE = ProductType.DomainController;
+    }
+
+    internal static class WindowsVistaRules
+    {
+        internal const int MAJORVERSION = 6;
+        internal const int MINORVERSION = 0;
+        internal const ProductType PRODUCTTYPE = ProductType.Workstation;        
+    }
+
+    /// <summary>
+    /// Windows Server 2003 R2 detection rules
+    /// </summary>
+    /// <remarks>https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa</remarks>
+    internal static class WindowsServer2003R2Rules
+    {
+        internal const int MAJORVERSION = 5;
+        internal const int MINORVERSION = 2;
+        internal static readonly List<KeyValuePair<SystemMetric, int>> SYSTEMMETRICS = new List<KeyValuePair<SystemMetric, int>>()
+                                            { new KeyValuePair<SystemMetric, int>( SystemMetric.SM_SERVERR2, 1 ) };
+    }
+
+    /// <summary>
+    /// Windows Server 2003 detection rules
+    /// </summary>
+    /// <remarks>https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa</remarks>
+    internal static class WindowsServer2003Rules
+    {
+        internal const int MAJORVERSION = 5;
+        internal const int MINORVERSION = 2;
+        internal static readonly List<KeyValuePair<SystemMetric, int>> SYSTEMMETRICS = new List<KeyValuePair<SystemMetric, int>>()
+                                            { new KeyValuePair<SystemMetric, int>( SystemMetric.SM_SERVERR2, 0 ) };
+    }
+
+    internal static class WindowsNomeServerRules
+    {
+        internal const int MAJORVERSION = 5;
+        internal const int MINORVERSION = 2;
+        internal const SuiteMask SUITEMASK = SuiteMask.VER_SUITE_WH_SERVER;
+    }
+    
+    internal static class WindowsXPProx64Rules
+    {
+        internal const int MAJORVERSION = 5;
+        internal const int MINORVERSION = 2;
+        internal const ProductType PRODUCTTYPE = ProductType.Workstation;
+        // TODO: x64 detection without NET Framework 4.0
+
+        static WindowsXPProx64Rules()
+        {
+            throw new NotImplementedException("Detection currently relies on Environment.Is64BitOperatingSystem.");
+        }
+    }
+
+    internal static class WindowsXPRules
+    {
+        internal const int MAJORVERSION = 5;
+        internal const int MINORVERSION = 1;        
+    }
+
+    internal static class Windows2000Rules
+    {
+        internal const int MAJORVERSION = 5;
+        internal const int MINORVERSION = 0;
+    }
+
+}

--- a/sources/OSVersionExtensionTests/OSVersionExtensionTests/OSDetectionTests.cs
+++ b/sources/OSVersionExtensionTests/OSVersionExtensionTests/OSDetectionTests.cs
@@ -1,0 +1,481 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OSVersionExt;
+using OSVersionExt.Win32API;
+using OSVersionExtension;
+
+namespace OSVersionExtensionTests
+{
+    [TestClass]
+    public class OSDetectionTests
+    {
+        [DataTestMethod]
+        [DataRow(Windows10Rules.MAJORVERSION, Windows10Rules.MINORVERSION, Windows10Rules.PRODUCTTYPE)]
+        public void DetectWindows10(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.Windows10, operatingSystem);
+        }
+
+
+        [DataTestMethod]
+        [DataRow(WindowsServer20162019ServerRules.MAJORVERSION, WindowsServer20162019ServerRules.MINORVERSION,
+            WindowsServer20162019ServerRules.PRODUCTTYPE)]
+        [DataRow(WindowsServer20162019DomainControllerRules.MAJORVERSION, WindowsServer20162019DomainControllerRules.MINORVERSION,
+            WindowsServer20162019DomainControllerRules.PRODUCTTYPE)]
+        public void DetectWindowsServer20162019(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsServer20162019, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(WindowsServer2012R2ServerRules.MAJORVERSION, WindowsServer2012R2ServerRules.MINORVERSION,
+            WindowsServer2012R2ServerRules.PRODUCTTYPE)]
+        [DataRow(WindowsServer2012R29DomainControllerRules.MAJORVERSION, WindowsServer2012R29DomainControllerRules.MINORVERSION,
+            WindowsServer2012R29DomainControllerRules.PRODUCTTYPE)]
+        public void DetectWindowsServer2012R2(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsServer2012R2, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(Windows81Rules.MAJORVERSION, Windows81Rules.MINORVERSION, Windows81Rules.PRODUCTTYPE)]
+        public void DetectWindows81(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.Windows81, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(Windows8Rules.MAJORVERSION, Windows8Rules.MINORVERSION, Windows8Rules.PRODUCTTYPE)]
+        public void DetectWindows8(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.Windows8, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(WindowsServer2012ServerRules.MAJORVERSION, WindowsServer2012ServerRules.MINORVERSION,
+            WindowsServer2012ServerRules.PRODUCTTYPE)]
+        [DataRow(WindowsServer2012DomainControllerRules.MAJORVERSION, WindowsServer2012DomainControllerRules.MINORVERSION,
+            WindowsServer2012DomainControllerRules.PRODUCTTYPE)]
+        public void DetectWindowsServer2012(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsServer2012, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(Windows7Rules.MAJORVERSION, Windows7Rules.MINORVERSION, Windows7Rules.PRODUCTTYPE)]
+        public void DetectWindows7(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.Windows7, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(WindowsServer2008R2ServerRules.MAJORVERSION, WindowsServer2008R2ServerRules.MINORVERSION,
+            WindowsServer2008R2ServerRules.PRODUCTTYPE)]
+        [DataRow(WindowsServer2008R2DomainControllerRules.MAJORVERSION, WindowsServer2008R2DomainControllerRules.MINORVERSION,
+            WindowsServer2008R2DomainControllerRules.PRODUCTTYPE)]
+        public void DetectWindowsServer2008R2(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsServer2008R2, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(WindowsServer2008ServerRules.MAJORVERSION, WindowsServer2008ServerRules.MINORVERSION,
+            WindowsServer2008ServerRules.PRODUCTTYPE)]
+        [DataRow(WindowsServer2008DomainControllerRules.MAJORVERSION, WindowsServer2008DomainControllerRules.MINORVERSION,
+            WindowsServer2008DomainControllerRules.PRODUCTTYPE)]
+        public void DetectWindowsServer2008(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsServer2008, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(WindowsVistaRules.MAJORVERSION, WindowsVistaRules.MINORVERSION, WindowsVistaRules.PRODUCTTYPE)]
+        public void DetectWindowsVista(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsVista, operatingSystem);
+        }
+
+        /// <summary>
+        /// Check if Windows Server 2003 R2 is properly detected. According to Microsoft documentation, ProductType does not apply for this version,
+        /// but SM_SERVERR2 != 0
+        /// </summary>
+        /// <param name="majorVersion"></param>
+        /// <param name="minorVersion"></param>
+        /// <remarks>https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa</remarks>
+        [DataTestMethod]
+        [DataRow(WindowsServer2003R2Rules.MAJORVERSION, WindowsServer2003R2Rules.MINORVERSION)]
+        public void DetectWindowsServer2003R2(int majorVersion, int minorVersion)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            List<KeyValuePair<SystemMetric, int>> systemMetrics = WindowsServer2003R2Rules.SYSTEMMETRICS;
+
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock, systemMetrics);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsServer2003R2, operatingSystem);
+        }
+
+        /// <summary>
+        /// Check if Windows Server 2003 is properly detected. According to Microsoft documentation, ProductType does not apply for this version,
+        /// but SM_SERVERR2 == 0
+        /// </summary>
+        /// <param name="majorVersion"></param>
+        /// <param name="minorVersion"></param>
+        /// <remarks>https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa</remarks>
+        [DataTestMethod]
+        [DataRow(WindowsServer2003Rules.MAJORVERSION, WindowsServer2003Rules.MINORVERSION)]
+        public void DetectWindowsServer2003(int majorVersion, int minorVersion)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            List<KeyValuePair<SystemMetric, int>> systemMetrics = WindowsServer2003Rules.SYSTEMMETRICS;
+
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock, systemMetrics);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsServer2003, operatingSystem);
+        }
+
+
+        [DataTestMethod]
+        [DataRow(WindowsNomeServerRules.MAJORVERSION, WindowsNomeServerRules.MINORVERSION, WindowsNomeServerRules.SUITEMASK)]
+        public void DetectWindowsHomeServer(int majorVersion, int minorVersion, SuiteMask suiteMask)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.SuiteMask = suiteMask;
+
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsHomeServer, operatingSystem);
+        }
+
+        /// <summary>
+        /// Windows XP Pro 64 Bit TODO: x64 detection without NET Framework 4.0
+        /// </summary>
+        /// <param name="majorVersion"></param>
+        /// <param name="minorVersion"></param>
+        /// <param name="productType"></param>
+        [Ignore]
+        [DataTestMethod]
+        [DataRow(WindowsXPProx64Rules.MAJORVERSION, WindowsXPProx64Rules.MINORVERSION, WindowsXPProx64Rules.PRODUCTTYPE)]
+        public void DetectWindowsXPProx64(int majorVersion, int minorVersion, ProductType productType)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+            osVersionInfoMock.ProductType = productType;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsXPProx64, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(WindowsXPRules.MAJORVERSION, WindowsXPRules.MINORVERSION)]
+        public void DetectWindowsXP(int majorVersion, int minorVersion)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.WindowsXP, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(Windows2000Rules.MAJORVERSION, Windows2000Rules.MINORVERSION)]
+        public void DetectWindows2000(int majorVersion, int minorVersion)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.Windows2000, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(112233,0)]
+        [DataRow(0, 112233)]
+        public void UnknownWindowsOnUnknownVersionInformation(int majorVersion, int minorVersion)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.Unknown, operatingSystem);
+        }
+
+        [DataTestMethod]
+        [DataRow(0, 0)]        
+        public void UnknownWindowsWhenVersionHasZeroValues(int majorVersion, int minorVersion)
+        {
+            // arrange            
+            var osVersionInfoMock = new OSVERSIONINFOEX { OSVersionInfoSize = Marshal.SizeOf(typeof(OSVERSIONINFOEX)) };
+
+            osVersionInfoMock.MajorVersion = majorVersion;
+            osVersionInfoMock.MinorVersion = minorVersion;
+
+            Win32ApiProviderMock win32ApiProviderMock = new Win32ApiProviderMock(osVersionInfoMock);
+            OSVersion.SetWin32ApiProvider(win32ApiProviderMock);
+
+            // act
+            OSVersionExtension.OperatingSystem operatingSystem = OSVersion.GetOperatingSystem();
+
+            // assert
+            Assert.AreEqual(OSVersionExtension.OperatingSystem.Unknown, operatingSystem);
+        }
+
+    }
+
+    /// <summary>
+    /// Mock for Win32 API environment.
+    /// </summary>
+    public class Win32ApiProviderMock : IWin32API
+    {
+        private OSVERSIONINFOEX _versionInfo;
+        private List<KeyValuePair<SystemMetric, int>> _systemMetrics;
+
+        public NTSTATUS RtlGetVersion(ref OSVERSIONINFOEX versionInfo)
+        {
+            versionInfo = _versionInfo;
+            return NTSTATUS.STATUS_SUCCESS;
+        }
+
+        /// <summary>
+        /// If the function succeeds, the return value is the requested system metric or configuration setting.
+        /// If the function fails, the return value is 0
+        /// </summary>
+        /// <param name="smIndex"></param>
+        /// <returns></returns>
+        public int GetSystemMetrics(SystemMetric smIndex)
+        {
+            if (_systemMetrics != null)
+                return _systemMetrics.Find(x => x.Key == smIndex).Value;
+            return 0;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the Win32 API mock.
+        /// </summary>
+        /// <param name="versionInfo">Provide the desired versino information which should be returned by RtlGetVersion</param>
+        /// <param name="systemMetrics">Provide the system metrics which should be returned by the Win32 API mock GetSystemMetrics.</param>
+        public Win32ApiProviderMock(OSVERSIONINFOEX versionInfo, List<KeyValuePair<SystemMetric, int>> systemMetrics )
+        {
+            _versionInfo = versionInfo;
+            _systemMetrics = systemMetrics;
+        }
+
+        /// <summary>
+        /// Creates a new instance of the Win32 API mock.
+        /// </summary>
+        /// <param name="versionInfo">Provide the desired versino information which should be returned by RtlGetVersion</param>        
+
+        public Win32ApiProviderMock(OSVERSIONINFOEX versionInfo)
+        {
+            _versionInfo = versionInfo;
+        }
+
+    }
+}

--- a/sources/OSVersionExtensionTests/OSVersionExtensionTests/OSVersionExtensionTests.csproj
+++ b/sources/OSVersionExtensionTests/OSVersionExtensionTests/OSVersionExtensionTests.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5E9D9588-51D2-4658-8CE5-C061F36E9499}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>OSVersionExtensionTests</RootNamespace>
+    <AssemblyName>OSVersionExtensionTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="OSDetectionRules.cs" />
+    <Compile Include="OSDetectionTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\OSVersionExt\OSVersionExtension.csproj">
+      <Project>{01df3d9f-dfb1-4bd5-b0bf-b9cbbe3ae19f}</Project>
+      <Name>OSVersionExtension</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\examples\DetectWindowsVersionExample\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/sources/OSVersionExtensionTests/OSVersionExtensionTests/Properties/AssemblyInfo.cs
+++ b/sources/OSVersionExtensionTests/OSVersionExtensionTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("OSVersionExtensionTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OSVersionExtensionTests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("5e9d9588-51d2-4658-8ce5-c061f36e9499")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/sources/OSVersionExtensionTests/OSVersionExtensionTests/packages.config
+++ b/sources/OSVersionExtensionTests/OSVersionExtensionTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
the detection of the various Windows operating systems is now checked by unit tests using a mock for the Win32 API calls